### PR TITLE
Add refund and delete sync between cash register and service

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,5 +4,6 @@ use EtsvThor\CashRegisterBridge\Http\Controllers\CashRegisterController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('webhooks/cashregister-bridge/set-as-paid', [CashRegisterController::class, 'setAsPaid']);
+Route::post('webhooks/cashregister-bridge/set-as-refunded', [CashRegisterController::class, 'setAsRefunded']);
 Route::post('cashregister-bridge/redirect-to-cash-register', [CashRegisterController::class, 'redirectToCashRegister'])
     ->name('cashregister.redirect');

--- a/src/Contracts/HasExternalProductItem.php
+++ b/src/Contracts/HasExternalProductItem.php
@@ -10,5 +10,6 @@ interface HasExternalProductItem
     public function externalProductItemRelationship(): string;
 
     public function setAsExternallyPaid(): bool;
+    public function setAsExternallyRefunded(): bool;
     public function isPaid(): bool;
 }

--- a/src/Exceptions/SetAsPaidFailed.php
+++ b/src/Exceptions/SetAsPaidFailed.php
@@ -2,9 +2,18 @@
 
 namespace EtsvThor\CashRegisterBridge\Exceptions;
 
+use EtsvThor\CashRegisterBridge\Contracts\HasExternalProductItem;
 use Exception;
+use Illuminate\Database\Eloquent\Model;
 
 class SetAsPaidFailed extends Exception
 {
-    //
+    public function __construct(HasExternalProductItem&Model $model, int $code = 0, ?Throwable $previous = null)
+    {
+        $message = __("Set as paid failed for :type#:id", [
+            'type' => $model::class,
+            'id' => $model->getKey(),
+        ]);
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Exceptions/SetAsRefundedFailed.php
+++ b/src/Exceptions/SetAsRefundedFailed.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EtsvThor\CashRegisterBridge\Exceptions;
+
+use Exception;
+
+class SetAsRefundedFailed extends Exception
+{
+    //
+}

--- a/src/Exceptions/SetAsRefundedFailed.php
+++ b/src/Exceptions/SetAsRefundedFailed.php
@@ -2,9 +2,18 @@
 
 namespace EtsvThor\CashRegisterBridge\Exceptions;
 
+use EtsvThor\CashRegisterBridge\Contracts\HasExternalProductItem;
 use Exception;
+use Illuminate\Database\Eloquent\Model;
 
 class SetAsRefundedFailed extends Exception
 {
-    //
+    public function __construct(HasExternalProductItem&Model $model, int $code = 0, ?Throwable $previous = null)
+    {
+        $message = __("Set as refunded failed for :type#:id", [
+            'type' => $model::class,
+            'id' => $model->getKey(),
+        ]);
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Http/Controllers/CashRegisterController.php
+++ b/src/Http/Controllers/CashRegisterController.php
@@ -19,7 +19,7 @@ class CashRegisterController
 
     public function setAsPaid(SetAsPaidRequest $request)
     {
-        if (!is_null($error = $this->verifySignature($request, config('cashregister-bridge.secret')))) {
+        if (! is_null($error = $this->verifySignature($request, config('cashregister-bridge.secret')))) {
             return $error;
         }
 
@@ -37,7 +37,7 @@ class CashRegisterController
 
     public function setAsRefunded(SetAsRefundedRequest $request)
     {
-        if (!is_null($error = $this->verifySignature($request, config('cashregister-bridge.secret')))) {
+        if (! is_null($error = $this->verifySignature($request, config('cashregister-bridge.secret')))) {
             return $error;
         }
 

--- a/src/Http/Controllers/CashRegisterController.php
+++ b/src/Http/Controllers/CashRegisterController.php
@@ -10,6 +10,7 @@ use EtsvThor\CashRegisterBridge\Http\Controllers\Traits\VerifiesSignature;
 use EtsvThor\CashRegisterBridge\Http\Requests\RedirectToCashRegisterRequest;
 use EtsvThor\CashRegisterBridge\Http\Requests\SetAsPaidRequest;
 use EtsvThor\CashRegisterBridge\Http\Requests\SetAsRefundedRequest;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -27,7 +28,7 @@ class CashRegisterController
 
         $success = $productItem->setAsExternallyPaid();
 
-        throw_unless($success, SetAsPaidFailed::class);
+        throw_unless($success, SetAsPaidFailed::class, $productItem);
 
         return [
             'success' => true,
@@ -45,7 +46,7 @@ class CashRegisterController
 
         $success = $productItem->setAsExternallyRefunded();
 
-        throw_unless($success, SetAsRefundedFailed::class);
+        throw_unless($success, SetAsRefundedFailed::class, $productItem);
 
         return [
             'success' => true,
@@ -81,9 +82,9 @@ class CashRegisterController
         return redirect($url);
     }
 
-    protected function getExternalProductItem(string $type, int $id): HasExternalProductItem
+    protected function getExternalProductItem(string $type, int $id): HasExternalProductItem&Model
     {
-        /** @var HasExternalProductItem $productItem */
+        /** @var HasExternalProductItem&Model $productItem */
         $productItem = $type::findOrFail($id);
 
         throw_unless($productItem instanceof HasExternalProductItem, HasNoExternalProductItem::class);

--- a/src/Http/Controllers/CashRegisterController.php
+++ b/src/Http/Controllers/CashRegisterController.php
@@ -5,9 +5,11 @@ namespace EtsvThor\CashRegisterBridge\Http\Controllers;
 use EtsvThor\CashRegisterBridge\Contracts\HasExternalProductItem;
 use EtsvThor\CashRegisterBridge\Exceptions\HasNoExternalProductItem;
 use EtsvThor\CashRegisterBridge\Exceptions\SetAsPaidFailed;
+use EtsvThor\CashRegisterBridge\Exceptions\SetAsRefundedFailed;
 use EtsvThor\CashRegisterBridge\Http\Controllers\Traits\VerifiesSignature;
 use EtsvThor\CashRegisterBridge\Http\Requests\RedirectToCashRegisterRequest;
 use EtsvThor\CashRegisterBridge\Http\Requests\SetAsPaidRequest;
+use EtsvThor\CashRegisterBridge\Http\Requests\SetAsRefundedRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -30,6 +32,24 @@ class CashRegisterController
         return [
             'success' => true,
             'message' => 'The item has been set as paid',
+        ];
+    }
+
+    public function setAsRefunded(SetAsRefundedRequest $request)
+    {
+        if (!is_null($error = $this->verifySignature($request, config('cashregister-bridge.secret')))) {
+            return $error;
+        }
+
+        $productItem = $this->getExternalProductItem($request->validated('type'), $request->validated('id'));
+
+        $success = $productItem->setAsExternallyRefunded();
+
+        throw_unless($success, SetAsRefundedFailed::class);
+
+        return [
+            'success' => true,
+            'message' => 'The item has been set as refunded',
         ];
     }
 

--- a/src/Http/Requests/SetAsRefundedRequest.php
+++ b/src/Http/Requests/SetAsRefundedRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace EtsvThor\CashRegisterBridge\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SetAsRefundedRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'type' => 'required',
+            'id' => 'required|numeric|min:1',
+        ];
+    }
+}

--- a/src/Jobs/DeleteExternalProduct.php
+++ b/src/Jobs/DeleteExternalProduct.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace EtsvThor\CashRegisterBridge\Jobs;
+
+use App\Mail\PublicRelationsMail;
+use App\Models\ContentTypes\Company;
+use App\Models\Role;
+use Carbon\Carbon;
+use EtsvThor\CashRegisterBridge\Contracts\HasExternalProduct;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+class DeleteExternalProduct implements ShouldQueue
+{
+    use Queueable, SerializesModels, InteractsWithQueue, Dispatchable;
+
+    public function __construct(
+        public HasExternalProduct $externalProduct
+    ) {}
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $service_id = config('cashregister-bridge.service_id');
+        $url = Str::of(config('cashregister-bridge.base_url'))->finish('/')->append("api/services/{$service_id}/service-products")->toString();
+
+        // Make sure the connection (and thus the data) is secure, except for local testing
+        if (! App::environment('local') && ! Str::startsWith($url, 'https://')) {
+            Log::warning('Service#'.$service_id.' has an endpoint without https:// in front of the url.');
+            return;
+        }
+
+        Http::acceptJson()->withSignature(config('cashregister-bridge.secret'))->delete(
+            $url,
+            $this->externalProduct->toExternalProduct()->only(
+                'id',
+                'type',
+            )->toArray(),
+        )->throw();
+    }
+}

--- a/src/Jobs/DeleteExternalProductItem.php
+++ b/src/Jobs/DeleteExternalProductItem.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace EtsvThor\CashRegisterBridge\Jobs;
+
+use App\Mail\PublicRelationsMail;
+use App\Models\ContentTypes\Company;
+use App\Models\Role;
+use Carbon\Carbon;
+use EtsvThor\CashRegisterBridge\Contracts\HasExternalProduct;
+use EtsvThor\CashRegisterBridge\Contracts\HasExternalProductItem;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
+
+class DeleteExternalProductItem implements ShouldQueue
+{
+    use Queueable, SerializesModels, InteractsWithQueue, Dispatchable;
+
+    public function __construct(
+        public HasExternalProductItem $externalProductItem
+    ) {}
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $service_id = config('cashregister-bridge.service_id');
+        $url = Str::of(config('cashregister-bridge.base_url'))
+            ->finish('/')
+            ->append("api/services/{$service_id}/service-items")
+            ->toString();
+
+        // Make sure the connection (and thus the data) is secure, except for local testing
+        if (! App::environment('local') && ! Str::startsWith($url, 'https://')) {
+            Log::warning('Service#'.$service_id.' has an endpoint without https:// in front of the url.');
+            return;
+        }
+
+        Http::acceptJson()->withSignature(config('cashregister-bridge.secret'))->delete(
+            $url,
+            $this->externalProductItem->toExternalProductItem()->only(
+                'product_type',
+                'product_id',
+                'type',
+                'id'
+            )->toArray(),
+        )->throw();
+    }
+}

--- a/src/Traits/PushesExternalProduct.php
+++ b/src/Traits/PushesExternalProduct.php
@@ -3,6 +3,7 @@
 namespace EtsvThor\CashRegisterBridge\Traits;
 
 use EtsvThor\CashRegisterBridge\Contracts\HasExternalProduct;
+use EtsvThor\CashRegisterBridge\Jobs\DeleteExternalProduct;
 use EtsvThor\CashRegisterBridge\Jobs\PushExternalProduct;
 use Illuminate\Support\Facades\Http;
 
@@ -12,6 +13,10 @@ trait PushesExternalProduct
     {
         static::saved(function (HasExternalProduct $externalProduct) {
             PushExternalProduct::dispatch($externalProduct);
+        });
+
+        static::deleted(function (HasExternalProduct $externalProductItem) {
+            DeleteExternalProduct::dispatch($externalProductItem);
         });
     }
 }

--- a/src/Traits/PushesExternalProductItem.php
+++ b/src/Traits/PushesExternalProductItem.php
@@ -4,6 +4,7 @@ namespace EtsvThor\CashRegisterBridge\Traits;
 
 use EtsvThor\CashRegisterBridge\Contracts\HasExternalProduct;
 use EtsvThor\CashRegisterBridge\Contracts\HasExternalProductItem;
+use EtsvThor\CashRegisterBridge\Jobs\DeleteExternalProductItem;
 use EtsvThor\CashRegisterBridge\Jobs\PushExternalProduct;
 use EtsvThor\CashRegisterBridge\Jobs\PushExternalProductItem;
 use Illuminate\Support\Facades\Http;
@@ -14,6 +15,10 @@ trait PushesExternalProductItem
     {
         static::saved(function (HasExternalProductItem $externalProductItem) {
             PushExternalProductItem::dispatch($externalProductItem);
+        });
+
+        static::deleted(function (HasExternalProductItem $externalProductItem) {
+            DeleteExternalProductItem::dispatch($externalProductItem);
         });
     }
 }


### PR DESCRIPTION
Op de Thorsite kan `setAsExternallyRefunded` voor nu gewoon `true` returnen zonder iets te doen. De refunds wil ik voor de TesLAN site syncen zodat de commissie inzage heeft zonder toegang tot het finances admin pannel