### PR TITLE
Set completed

### DIFF
--- a/src/Contracts/HasExternalProductItem.php
+++ b/src/Contracts/HasExternalProductItem.php
@@ -8,7 +8,7 @@ interface HasExternalProductItem
 {
     public function toExternalProductItem(): ExternalProductItem;
     public function externalProductItemRelationship(): string;
-
+    public function setAsCompleted(): bool;
     public function setAsExternallyPaid(): bool;
     public function setAsExternallyRefunded(): bool;
     public function isPaid(): bool;

--- a/src/Http/Controllers/CashRegisterController.php
+++ b/src/Http/Controllers/CashRegisterController.php
@@ -27,6 +27,9 @@ class CashRegisterController
         $productItem = $this->getExternalProductItem($request->validated('type'), $request->validated('id'));
 
         $success = $productItem->setAsExternallyPaid();
+        if ($success && ! is_null($request->validated('completed'))) {
+            $productItem->setAsCompleted();
+        }
 
         throw_unless($success, SetAsPaidFailed::class, $productItem);
 

--- a/src/Http/Controllers/CashRegisterController.php
+++ b/src/Http/Controllers/CashRegisterController.php
@@ -11,7 +11,6 @@ use EtsvThor\CashRegisterBridge\Http\Requests\RedirectToCashRegisterRequest;
 use EtsvThor\CashRegisterBridge\Http\Requests\SetAsPaidRequest;
 use EtsvThor\CashRegisterBridge\Http\Requests\SetAsRefundedRequest;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
 class CashRegisterController

--- a/src/Http/Requests/RedirectToCashRegisterRequest.php
+++ b/src/Http/Requests/RedirectToCashRegisterRequest.php
@@ -6,11 +6,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class RedirectToCashRegisterRequest extends FormRequest
 {
-    public function authorize()
-    {
-        return true;
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *

--- a/src/Http/Requests/SetAsPaidRequest.php
+++ b/src/Http/Requests/SetAsPaidRequest.php
@@ -6,11 +6,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class SetAsPaidRequest extends FormRequest
 {
-    public function authorize()
-    {
-        return true;
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *

--- a/src/Http/Requests/SetAsPaidRequest.php
+++ b/src/Http/Requests/SetAsPaidRequest.php
@@ -21,6 +21,7 @@ class SetAsPaidRequest extends FormRequest
         return [
             'type' => 'required',
             'id' => 'required|numeric|min:1',
+            'completed' => 'nullable|accepted',
         ];
     }
 }

--- a/src/Http/Requests/SetAsRefundedRequest.php
+++ b/src/Http/Requests/SetAsRefundedRequest.php
@@ -6,11 +6,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class SetAsRefundedRequest extends FormRequest
 {
-    public function authorize()
-    {
-        return true;
-    }
-
     /**
      * Get the validation rules that apply to the request.
      *

--- a/src/Traits/PushesExternalProduct.php
+++ b/src/Traits/PushesExternalProduct.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Http;
 
 trait PushesExternalProduct
 {
-    public static function bootPushesExternalProduct()
+    public static function bootPushesExternalProduct(): void
     {
         static::saved(function (HasExternalProduct $externalProduct) {
             PushExternalProduct::dispatch($externalProduct);

--- a/src/Traits/PushesExternalProductItem.php
+++ b/src/Traits/PushesExternalProductItem.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Http;
 
 trait PushesExternalProductItem
 {
-    public static function bootPushesExternalProductItem()
+    public static function bootPushesExternalProductItem(): void
     {
         static::saved(function (HasExternalProductItem $externalProductItem) {
             PushExternalProductItem::dispatch($externalProductItem);


### PR DESCRIPTION
Vanuit de kassa een item op `completed` zetten is handig. Bijv. bij betalen en meteen uitgeven van sexy tappers kalenders