### PR TITLE
Fix getExternalProductItem for softdeletes models

### DIFF
--- a/src/Http/Controllers/CashRegisterController.php
+++ b/src/Http/Controllers/CashRegisterController.php
@@ -92,7 +92,9 @@ class CashRegisterController
             : ['*'];
 
         /** @var HasExternalProductItem&Model $productItem */
-        if (method_exists($type, 'withThrashed')) {
+
+
+        if (method_exists($type, 'bootSoftDeletes')) {
             $productItem = $type::withTrashed()->findOrFail($id, $columns);
         } else {
             $productItem = $type::findOrFail($id, $columns);

--- a/src/Http/Controllers/CashRegisterController.php
+++ b/src/Http/Controllers/CashRegisterController.php
@@ -92,8 +92,6 @@ class CashRegisterController
             : ['*'];
 
         /** @var HasExternalProductItem&Model $productItem */
-
-
         if (method_exists($type, 'bootSoftDeletes')) {
             $productItem = $type::withTrashed()->findOrFail($id, $columns);
         } else {


### PR DESCRIPTION
De if statements is nu false op de TesLAN website omdat die niet goed werkt. Hierdoor zijn een paar payments to service gefaalt bij payments die lang duurden (heb voor nu via tinker gerestored en de job geretried)

https://finances.thor.edu/horizon/failed/86a5c348-89c1-4204-aa08-60a09e8686b1
https://finances.thor.edu/horizon/failed/4c733cf9-5ba6-45ad-8a82-4e74b8e50463

Ik zal zo op de TesLAN website ook wat testcases hiervoor maken, zodat dit niet opnieuw stuk kan gaan